### PR TITLE
[CATKIN LINT] clean up CMakeLists.txt

### DIFF
--- a/cob_base_velocity_smoother/CMakeLists.txt
+++ b/cob_base_velocity_smoother/CMakeLists.txt
@@ -1,7 +1,14 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(cob_base_velocity_smoother)
 
-find_package(catkin REQUIRED COMPONENTS dynamic_reconfigure geometry_msgs nav_msgs roscpp std_msgs)
+find_package(catkin REQUIRED
+  COMPONENTS
+    dynamic_reconfigure
+    geometry_msgs
+    nav_msgs
+    roscpp
+    std_msgs
+)
 
 find_package(Boost REQUIRED thread)
 
@@ -13,10 +20,15 @@ else()
   add_definitions(-std=c++0x)
 endif()
 
-catkin_package()
+catkin_package(
+  CATKIN_DEPENDS
+    geometry_msgs
+    nav_msgs
+    std_msgs
+)
 
 ### BUILD ###
-include_directories(include include/cob_base_velocity_smoother ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
+include_directories(include/cob_base_velocity_smoother ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 
 add_executable(${PROJECT_NAME} src/cob_base_velocity_smoother.cpp)
 add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})

--- a/cob_base_velocity_smoother/CMakeLists.txt
+++ b/cob_base_velocity_smoother/CMakeLists.txt
@@ -28,7 +28,7 @@ catkin_package(
 )
 
 ### BUILD ###
-include_directories(include/cob_base_velocity_smoother ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
+include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 
 add_executable(${PROJECT_NAME} src/cob_base_velocity_smoother.cpp)
 add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})

--- a/cob_base_velocity_smoother/src/cob_base_velocity_smoother.cpp
+++ b/cob_base_velocity_smoother/src/cob_base_velocity_smoother.cpp
@@ -48,7 +48,7 @@
  *
  ****************************************************************/
 
-#include <cob_base_velocity_smoother.h>
+#include <cob_base_velocity_smoother/cob_base_velocity_smoother.h>
 
 /****************************************************************
  * the ros navigation doesn't run very smoothly because acceleration is too high

--- a/cob_collision_velocity_filter/CMakeLists.txt
+++ b/cob_collision_velocity_filter/CMakeLists.txt
@@ -14,7 +14,12 @@ endif()
 ### Dynamic reconfigure ###
 generate_dynamic_reconfigure_options(cfg/CollisionVelocityFilter.cfg)
 
-catkin_package()
+catkin_package(
+  CATKIN_DEPENDS
+    geometry_msgs
+    nav_msgs
+    visualization_msgs
+)
 
 ### BUILD ###
 include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})

--- a/cob_control_mode_adapter/CMakeLists.txt
+++ b/cob_control_mode_adapter/CMakeLists.txt
@@ -1,11 +1,23 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(cob_control_mode_adapter)
 
-find_package(catkin REQUIRED COMPONENTS controller_manager_msgs roscpp std_msgs)
+find_package(catkin REQUIRED
+  COMPONENTS
+    controller_manager_msgs
+    roscpp
+    std_msgs
+)
 
-find_package(Boost REQUIRED COMPONENTS thread)
+find_package(Boost REQUIRED
+  COMPONENTS
+    thread
+)
 
-catkin_package()
+catkin_package(
+  CATKIN_DEPENDS
+   controller_manager_msgs
+   std_msgs
+)
 
 ### BUILD ###
 include_directories(${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})

--- a/cob_model_identifier/CMakeLists.txt
+++ b/cob_model_identifier/CMakeLists.txt
@@ -10,7 +10,11 @@ add_definitions(${EIGEN_DEFINITIONS})
 
 find_package(TinyXML REQUIRED)
 
-catkin_package()
+catkin_package(
+  CATKIN_DEPENDS
+    geometry_msgs
+    sensor_msgs
+)
 
 ### BUILD ###
 include_directories(include ${catkin_INCLUDE_DIRS} ${EIGEN_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})

--- a/cob_obstacle_distance/CMakeLists.txt
+++ b/cob_obstacle_distance/CMakeLists.txt
@@ -29,7 +29,24 @@ generate_messages(
 )
 
 catkin_package(
-  CATKIN_DEPENDS cob_srvs dynamic_reconfigure eigen_conversions geometry_msgs kdl_conversions kdl_parser message_runtime moveit_msgs roscpp roslib sensor_msgs shape_msgs std_msgs tf_conversions tf urdf visualization_msgs
+  CATKIN_DEPENDS
+    cob_srvs
+    dynamic_reconfigure
+    eigen_conversions
+    geometry_msgs
+    kdl_conversions
+    kdl_parser
+    message_runtime
+    moveit_msgs
+    roscpp
+    roslib
+    sensor_msgs
+    shape_msgs
+    std_msgs
+    tf_conversions
+    tf
+    urdf
+    visualization_msgs
   DEPENDS Boost
   INCLUDE_DIRS include
   LIBRARIES parsers marker_shapes_management

--- a/cob_trajectory_controller/CMakeLists.txt
+++ b/cob_trajectory_controller/CMakeLists.txt
@@ -8,7 +8,13 @@ generate_dynamic_reconfigure_options(
   cfg/CobTrajectoryController.cfg
 )
 
-catkin_package()
+catkin_package(
+  CATKIN_DEPENDS
+    control_msgs
+    sensor_msgs
+    std_msgs
+    trajectory_msgs
+)
 
 ### BUILD ###
 include_directories(common/include ${catkin_INCLUDE_DIRS})

--- a/cob_twist_controller/CMakeLists.txt
+++ b/cob_twist_controller/CMakeLists.txt
@@ -17,7 +17,21 @@ generate_dynamic_reconfigure_options(
 )
 
 catkin_package(
-  CATKIN_DEPENDS cob_obstacle_distance cob_srvs dynamic_reconfigure eigen_conversions geometry_msgs kdl_conversions kdl_parser nav_msgs roscpp sensor_msgs std_msgs tf urdf visualization_msgs
+  CATKIN_DEPENDS
+    cob_obstacle_distance
+    cob_srvs
+    dynamic_reconfigure
+    eigen_conversions
+    geometry_msgs
+    kdl_conversions
+    kdl_parser nav_msgs
+    roscpp
+    sensor_msgs
+    std_msgs
+    tf
+    trajectory_msgs
+    urdf
+    visualization_msgs
   DEPENDS Boost
   INCLUDE_DIRS include
   LIBRARIES damping_methods inv_calculations constraint_solvers limiters controller_interfaces kinematic_extensions inverse_differential_kinematics_solver twist_controller

--- a/cob_undercarriage_ctrl_node/CMakeLists.txt
+++ b/cob_undercarriage_ctrl_node/CMakeLists.txt
@@ -1,9 +1,28 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(cob_undercarriage_ctrl_node)
 
-find_package(catkin REQUIRED COMPONENTS cob_msgs cob_omni_drive_controller control_msgs diagnostic_msgs diagnostic_updater geometry_msgs nav_msgs roscpp tf urdf)
+find_package(catkin REQUIRED
+    COMPONENTS
+      cob_msgs
+      cob_omni_drive_controller
+      control_msgs
+      diagnostic_msgs
+      diagnostic_updater
+      geometry_msgs
+      nav_msgs
+      roscpp
+      tf
+      urdf
+)
 
-catkin_package()
+catkin_package(
+  CATKIN_DEPENDS
+    cob_msgs
+    control_msgs
+    diagnostic_msgs
+    geometry_msgs
+    nav_msgs
+)
 
 ###########
 ## Build ##


### PR DESCRIPTION
Fix all but one issues causing catkin_lint to fail.

Remaining warning is:
- cob_obstacle_distance: CMakeLists.txt(4): warning: variable
  CMAKE_CXX_FLAGS is modified
